### PR TITLE
Add support for detection in macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ the correct location of the executable.
 * `cppcheck.showStatusBarItem`: Show/hide the status bar item for displaying analyzer commands.
 * `cppcheck.lintingEnabled`: Whether to enable automatic linting for C/C++ code. Linting runs on workspace changes and file saves.
 
-## Known Issues
-
-Detection of cppcheck is limited to the 32-bit Windows executable and Linux. Mac detection does not exist.
-
 ## Release Notes
 
 ### 0.0.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # cppcheck README
 
 This extension utilizes the cppcheck static code analyzer to provide C and C++ code analysis within Visual Studio Code.
-Cppcheck is available at `http://cppcheck.sourceforge.net`.
 
 ## Features
 
@@ -13,9 +12,30 @@ Cppcheck is available at `http://cppcheck.sourceforge.net`.
 
 ## Requirements
 
-cppcheck must be installed. Any version may be used. The extension will try to locate the cppcheck executable if possible. It will search
-the 32-bit Program Files directory on Windows, and several bin directories on Linux. If not found, `cppcheck.cppcheckPath` must be set to
-the correct location of the executable.
+Cppcheck must be installed. Any version may be used. The extension will try to locate the `cppcheck` executable if possible. On Windows, it will search
+the 32-bit Program Files directory. On Linux and macOS, several bin directories will be searched.
+
+If `cppcheck` is not found, `cppcheck.cppcheckPath` must be set to the correct location of the executable.
+
+### Windows Installation
+
+Cppcheck is available for download at [`cppcheck.sourceforge.net`](http://cppcheck.sourceforge.net/).
+
+### Ubuntu Installation
+
+For Ubuntu users, Cppcheck is available via `apt-get`.
+
+```sh
+sudo apt-get install cppcheck
+```
+
+### macOS Installation
+
+For macOS users, Cppcheck can most easily be installed using [Homebrew](https://brew.sh/).
+
+```sh
+brew install cppcheck
+```
 
 ## Extension Settings
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -155,8 +155,8 @@ function findCppcheckPath(settings: vscode.WorkspaceConfiguration) {
                 cppcheckPath = file;
             }
         }
-        else if (p === 'linux') {
-            let attempts = [ '/usr/bin/cppcheck', '/usr/sbin/cppcheck', '/usr/share/bin/cppcheck' ];
+        else if (p === 'linux' || p === 'darwin') {
+            let attempts = [ '/usr/bin/cppcheck', '/usr/sbin/cppcheck', '/usr/share/bin/cppcheck', '/usr/local/bin/cppcheck' ];
             for (let index = 0; index < attempts.length; index++) {
                 if (existsSync(attempts[index])) {
                     cppcheckPath = attempts[index];


### PR DESCRIPTION
Thanks for the awesome plugin! 

This adds macOS (`darwin`) to the platforms searched (file paths will often be the same as `linux`) and `/usr/local/bin` to the paths searched – that's the location where Homebrew will link the `cppcheck` executable.

I also added some simple installation instructions for several platforms, hopefully they'll help others get started a little faster.