### PR TITLE
Output Severity Level settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,153 +1,214 @@
 {
-  "name": "cppcheck",
-  "displayName": "cppcheck",
-  "description": "Invokes the 'cppcheck' static C++ code analyzer.",
-  "version": "0.0.7",
-  "author": "Matthew Ferreira",
-  "publisher": "matthewferreira",
-  "license": "MIT",
-  "icon": "logo.png",
-  "repository": {
-    "type": "Git",
-    "url": "https://github.com/matthewferreira/cppcheck-extension"
-  },
-  "engines": {
-    "vscode": "^1.5.0"
-  },
-  "categories": [
-    "Linters"
-  ],
-  "activationEvents": [
-    "*"
-  ],
-  "main": "./out/src/extension",
-  "contributes": {
-    "commands": [
-      {
-        "command": "cppcheck.runAnalysis",
-        "title": "Analyze current file",
-        "category": "Cppcheck"
-      },
-      {
-        "command": "cppcheck.runAnalysisAllFiles",
-        "title": "Analyze workspace",
-        "category": "Cppcheck"
-      },
-      {
-        "command": "cppcheck.showCommands",
-        "title": "Show commands",
-        "category": "Cppcheck"
-      },
-      {
-        "command": "cppcheck.readTheManual",
-        "title": "Read the manual",
-        "category": "Cppcheck"
-      }
+    "name": "cppcheck",
+    "displayName": "cppcheck",
+    "description": "Invokes the 'cppcheck' static C++ code analyzer.",
+    "version": "0.0.7",
+    "author": "Matthew Ferreira",
+    "publisher": "matthewferreira",
+    "license": "MIT",
+    "icon": "logo.png",
+    "repository": {
+        "type": "Git",
+        "url": "https://github.com/matthewferreira/cppcheck-extension"
+    },
+    "engines": {
+        "vscode": "^1.5.0"
+    },
+    "categories": [
+        "Linters"
     ],
-    "configuration": {
-      "type": "object",
-      "title": "cppcheck",
-      "properties": {
-        "cppcheck.enable": {
-          "type": "boolean",
-          "default": true,
-          "description": "Controls whether cppcheck is enabled for C++ files."
-        },
-        "cppcheck.cppcheckPath": {
-          "type": "string",
-          "default": null,
-          "description": "The path to the cppcheck executable. If not set, the default location will be used."
-        },
-        "cppcheck.includePaths": {
-          "type": "array",
-          "default": [],
-          "description": "Paths to search for include files. They may be relative or absolute."
-        },
-        "cppcheck.platform": {
-          "type": "string",
-          "enum": [
-            "unix32",
-            "unix64",
-            "win32A",
-            "win32W",
-            "win64",
-            "native"
-          ],
-          "default": "native",
-          "description": "The platform used for types and sizes."
-        },
-        "cppcheck.standard": {
-          "type": "array",
-          "default": [
-            "c11",
-            "c++11"
-          ],
-          "description": "The language standards to check against. Can be one or more of: posix, c89, c99, c11, c++03, c++11."
-        },
-        "cppcheck.define": {
-          "type": "array",
-          "default": [],
-          "description": "Preprocessor symbols to define."
-        },
-        "cppcheck.undefine": {
-          "type": "array",
-          "default": [],
-          "description": "Preprocessor symbols to undefine."
-        },
-        "cppcheck.suppressions": {
-          "type": "array",
-          "default": [],
-          "description": "Warnings to suppress. Refer to the 'cppcheck' documentation for what to supply here."
-        },
-        "cppcheck.verbose": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether to enable verbose output from 'cppcheck'."
-        },
-        "cppcheck.showStatusBarItem": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to show a 'Cppcheck' item in the status bar for launching the static analyzer."
-        },
-        "cppcheck.showOutputAfterRunning": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to show the 'Cppcheck' output channel after running the analyzer."
-        },
-        "cppcheck.lintingEnabled": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether to enable automatic linting for C/C++ code. Linting runs when opening a workspace or saving a file."
+    "activationEvents": [
+        "*"
+    ],
+    "main": "./out/src/extension",
+    "contributes": {
+        "commands": [{
+                "command": "cppcheck.runAnalysis",
+                "title": "Analyze current file",
+                "category": "Cppcheck"
+            },
+            {
+                "command": "cppcheck.runAnalysisAllFiles",
+                "title": "Analyze workspace",
+                "category": "Cppcheck"
+            },
+            {
+                "command": "cppcheck.showCommands",
+                "title": "Show commands",
+                "category": "Cppcheck"
+            },
+            {
+                "command": "cppcheck.readTheManual",
+                "title": "Read the manual",
+                "category": "Cppcheck"
+            }
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "cppcheck",
+            "properties": {
+                "cppcheck.enable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Controls whether cppcheck is enabled for C++ files."
+                },
+                "cppcheck.cppcheckPath": {
+                    "type": "string",
+                    "default": null,
+                    "description": "The path to the cppcheck executable. If not set, the default location will be used."
+                },
+                "cppcheck.includePaths": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Paths to search for include files. They may be relative or absolute."
+                },
+                "cppcheck.platform": {
+                    "type": "string",
+                    "enum": [
+                        "unix32",
+                        "unix64",
+                        "win32A",
+                        "win32W",
+                        "win64",
+                        "native"
+                    ],
+                    "default": "native",
+                    "description": "The platform used for types and sizes."
+                },
+                "cppcheck.standard": {
+                    "type": "array",
+                    "default": [
+                        "c11",
+                        "c++11"
+                    ],
+                    "description": "The language standards to check against. Can be one or more of: posix, c89, c99, c11, c++03, c++11."
+                },
+                "cppcheck.define": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Preprocessor symbols to define."
+                },
+                "cppcheck.undefine": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Preprocessor symbols to undefine."
+                },
+                "cppcheck.suppressions": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Warnings to suppress. Refer to the 'cppcheck' documentation for what to supply here."
+                },
+                "cppcheck.verbose": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to enable verbose output from 'cppcheck'."
+                },
+                "cppcheck.showStatusBarItem": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to show a 'Cppcheck' item in the status bar for launching the static analyzer."
+                },
+                "cppcheck.showOutputAfterRunning": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to show the 'Cppcheck' output channel after running the analyzer."
+                },
+                "cppcheck.lintingEnabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to enable automatic linting for C/C++ code. Linting runs when opening a workspace or saving a file."
+                },
+                "cppcheck.severityLevels": {
+                    "type": "object",
+                    "description": "Maps the severity levels of cppcheck to VSCode severity levels (Error, Warning, Information, Hint). Setting to 'None' will not show the severity type at all",
+                    "default": {
+                        "error": "Error",
+                        "warning": "Warning",
+                        "style": "Information",
+                        "performance": "Warning",
+                        "portability": "Warning",
+                        "information": "Information"
+                    },
+                    "properties": {
+                        "error": {
+                            "description": "used when bugs are found",
+                            "type": "string",
+                            "default": "Error",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        },
+                        "warning": {
+                            "description": "suggestions about defensive programming to prevent bugs",
+                            "type": "string",
+                            "default": "Warning",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        },
+                        "style": {
+                            "description": "stylistic issues related to code cleanup (unused functions, redundant code, constness, and such)",
+                            "type": "string",
+                            "default": "Information",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        },
+                        "performance": {
+                            "description": "Suggestions for making the code faster. These suggestions are only based on common knowledge. It  is  not  certain  you'll  get  any  measurable  difference  in  speed  by  fixing these messages",
+                            "type": "string",
+                            "default": "Warning",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        },
+                        "portability": {
+                            "description": "portability  warnings.  64-bit  portability.  code  might  work  different  on  different compilers. etc.",
+                            "type": "string",
+                            "default": "Warning",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        },
+                        "information": {
+                            "description": "Configuration   problems.   The   recommendation   is   to   only   enable   these   during configuration.",
+                            "type": "string",
+                            "default": "Information",
+                            "enum": [
+                                "Error", "Warning", "Hint", "Information", "None"
+                            ]
+                        }
+                    }
+                }
+            }
         }
-      }
+    },
+    "scripts": {
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -p ./",
+        "build": "npm run compile",
+        "build:watch": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "pkgvars": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
+    },
+    "devDependencies": {
+        "@types/lodash": "^4.14.62",
+        "@types/mocha": "^2.2.40",
+        "@types/node": "^7.0.12",
+        "@types/opn": "^3.0.28",
+        "eslint": "^3.19.0",
+        "mocha": "^3.2.0",
+        "os": "^0.1.1",
+        "tslint": "^5.1.0",
+        "typescript": "^2.2.2",
+        "vscode": "^1.1.0"
+    },
+    "dependencies": {
+        "child_process": "^1.0.2",
+        "fs": "0.0.1-security",
+        "lodash": "^4.17.4",
+        "opn": "^4.0.2",
+        "os": "^0.1.1"
     }
-  },
-  "scripts": {
-    "vscode:prepublish": "tsc -p ./",
-    "compile": "tsc -p ./",
-    "build": "npm run compile",
-    "build:watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
-    "pkgvars": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test"
-  },
-  "devDependencies": {
-    "@types/lodash": "^4.14.62",
-    "@types/mocha": "^2.2.40",
-    "@types/node": "^7.0.12",
-    "@types/opn": "^3.0.28",
-    "eslint": "^3.19.0",
-    "mocha": "^3.2.0",
-    "os": "^0.1.1",
-    "tslint": "^5.1.0",
-    "typescript": "^2.2.2",
-    "vscode": "^1.1.0"
-  },
-  "dependencies": {
-    "child_process": "^1.0.2",
-    "fs": "0.0.1-security",
-    "lodash": "^4.17.4",
-    "opn": "^4.0.2",
-    "os": "^0.1.1"
-  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,8 +202,7 @@ function configChanged() {
             style: 'Information',
             performance: 'Warning',
             portability: 'Warning',
-            information: 'Information',
-            unknown: 'None'
+            information: 'Information'
         });
 
         let standard = settings.get('standard', [ 'c11', 'c++11' ]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,15 @@ function configChanged() {
         config['verbose'] = settings.get('verbose', false);
         config['showOutputAfterRunning'] = settings.get('showOutputAfterRunning', true);
         config['lintingEnabled'] = settings.get('lintingEnabled', false);
+        config['severityLevels'] = settings.get('severityLevels', {
+            error: 'Error',
+            warning: 'Warning',
+            style: 'Information',
+            performance: 'Warning',
+            portability: 'Warning',
+            information: 'Information',
+            unknown: 'None'
+        });
 
         let standard = settings.get('standard', [ 'c11', 'c++11' ]);
         let outStandard: string[] = [];

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -34,14 +34,14 @@ function cppcheckSeverityToDiagnosticSeverity(severity: string, config: Severity
     return (<any>vscode.DiagnosticSeverity)[cpplevel] as vscode.DiagnosticSeverity;
 }
 
-export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: {[key:string]:any}) {
+export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: { [key: string]: any }) {
     diagnosticCollection.clear();
 
     // 1 = path, 2 = line, 3 = severity, 4 = message
     let regex = /^(?:\[([\w:\\/.-]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
     let cppcheckOutput = runOnWorkspace(config, vscode.workspace.rootPath);
     let regexArray: RegExpExecArray;
-    let fileData: {[key:string]:RegExpExecArray[]} = {};
+    let fileData: { [key: string]: RegExpExecArray[] } = {};
     while (regexArray = regex.exec(cppcheckOutput)) {
         if (regexArray[1] === undefined || regexArray[2] === undefined || regexArray[3] === undefined || regexArray[4] === undefined) {
             continue;
@@ -69,9 +69,12 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
 
                 let l = doc.lineAt(line);
                 let r = new vscode.Range(line, l.text.match(/\S/).index, line, l.text.length);
-                let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, cppcheckSeverityToDiagnosticSeverity(severity, config['severityLevels'] as SeverityMaps));
-                d.source = 'cppcheck';
-                diagnostics.push(d);
+                const level = cppcheckSeverityToDiagnosticSeverity(severity, config['severityLevels'] as SeverityMaps);
+                if (level !== undefined) {
+                    let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, );
+                    d.source = 'cppcheck';
+                    diagnostics.push(d);
+                }
             }
             diagnosticCollection.set(doc.uri, diagnostics);
         });

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -71,7 +71,7 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
                 let r = new vscode.Range(line, l.text.match(/\S/).index, line, l.text.length);
                 const level = cppcheckSeverityToDiagnosticSeverity(severity, config['severityLevels'] as SeverityMaps);
                 if (level !== undefined) {
-                    let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, );
+                    let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, level);
                     d.source = 'cppcheck';
                     diagnostics.push(d);
                 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -9,6 +9,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { runOnWorkspace } from './analyzer';
 
+type SeverityLevel = 'Error' | 'Warning' | 'Information' | 'Hint' | 'None';
+interface SeverityMaps {
+    error: SeverityLevel;
+    warning: SeverityLevel;
+    style: SeverityLevel;
+    performance: SeverityLevel;
+    portability: SeverityLevel;
+    information: SeverityLevel;
+}
+
 function getCorrectFileName(p: string): string {
     if (!fs.existsSync(p)) {
         p = path.join(vscode.workspace.rootPath, p);
@@ -19,18 +29,9 @@ function getCorrectFileName(p: string): string {
     return p;
 }
 
-function cppcheckSeverityToDiagnosticSeverity(severity: string): vscode.DiagnosticSeverity {
-    switch (severity) {
-        case 'error':
-            return vscode.DiagnosticSeverity.Error;
-        case 'warning':
-            return vscode.DiagnosticSeverity.Warning;
-        case 'performance':
-        case 'portability':
-            return vscode.DiagnosticSeverity.Hint;
-        default:
-            return vscode.DiagnosticSeverity.Information;
-    }
+function cppcheckSeverityToDiagnosticSeverity(severity: string, config: SeverityMaps): vscode.DiagnosticSeverity {
+    const cpplevel = (<any>config)[severity] as string;
+    return (<any>vscode.DiagnosticSeverity)[cpplevel] as vscode.DiagnosticSeverity;
 }
 
 export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: {[key:string]:any}) {
@@ -68,7 +69,7 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
 
                 let l = doc.lineAt(line);
                 let r = new vscode.Range(line, l.text.match(/\S/).index, line, l.text.length);
-                let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, cppcheckSeverityToDiagnosticSeverity(severity));
+                let d = new vscode.Diagnostic(r, `(${severity}) ${message}`, cppcheckSeverityToDiagnosticSeverity(severity, config['severityLevels'] as SeverityMaps));
                 d.source = 'cppcheck';
                 diagnostics.push(d);
             }


### PR DESCRIPTION
Hi @matthewferreira,

Thanks for including the highlighting for cppcheck messages. I worked on settings to give the user the possibility mapping the cppcheck output to the diagnostic severity levels. I would like to have performance and style issues as warnings, for example, to see, if I can boost my code there.

You can try it out and acces them in the user / workspace settings. It is the setting cppcheck.severityLevels.

Could you provide this in the next update?