### PR TITLE
Adds option to force cppcheck to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ to enable linting per-workspace.
 * `cppcheck.undefine`: Symbols to undefine for the preprocessor.
 * `cppcheck.suppressions`: Any cppcheck rules to suppress (see the cppcheck manual).
 * `cppcheck.verbose`: Enable verbose output from cppcheck.
+* `cppcheck.force`: Enable forcefully analyzing all possible configurations through cppcheck.
 * `cppcheck.showStatusBarItem`: Show/hide the status bar item for displaying analyzer commands.
 * `cppcheck.lintingEnabled`: Whether to enable automatic linting for C/C++ code. Linting runs on workspace changes and file saves.
 * `cppcheck.outputCommandLine`: Whether to output the command line used to invoke Cppcheck.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,11 @@
           "default": false,
           "description": "Whether to enable verbose output from 'cppcheck'."
         },
+        "cppcheck.force": {
+          "type": "boolean",
+          "default": false,
+          "description": "Controls whether cppcheck enumerates all possible configurations."
+        },
         "cppcheck.showStatusBarItem": {
           "type": "boolean",
           "default": true,

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -55,11 +55,12 @@ export function runLintMode(config: {[key:string]:any}, workspaceDir: string) {
 
 function runCppcheck(params: string[], config: {[key:string]:any}, workspaceDir: string) {
     let start = 'Cppcheck started: ' + new Date().toString();
+    let runArgs = 'Running with: ' + params.join(' ');
     let result = spawnSync(config['cppcheckPath'], params, { 'cwd': workspaceDir } );
     let stdout = '' + result.stdout;
     let stderr = '' + result.stderr;
     let end = 'Cppcheck ended: ' + new Date().toString();
-    let resultsArray = [start, stdout, stderr, end];
+    let resultsArray = [start, runArgs, stdout, stderr, end];
 
     if (config['outputCommandLine']) {
         let commandLine = `${config['cppcheckPath']} ${params.join(' ')}`;
@@ -90,6 +91,10 @@ function getCppcheckParameters(config: {[key:string]:any}, unusedFunction: boole
 
     if (useVerbose && config['verbose'] === true) {
         params.push('--verbose');
+    }
+
+    if (config['force'] === true) {
+        params.push('--force');
     }
 
     return params;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,6 +195,7 @@ function configChanged() {
         config['undefine'] = settings.get('undefine', []);
         config['suppressions'] = settings.get('suppressions', []);
         config['verbose'] = settings.get('verbose', false);
+        config['force'] = settings.get('force', false);
         config['showOutputAfterRunning'] = settings.get('showOutputAfterRunning', true);
         config['lintingEnabled'] = settings.get('lintingEnabled', false);
         config['outputCommandLine'] = settings.get('outputCommandLine', false);


### PR DESCRIPTION
Adds an option to force `cppcheck` to analyze files that are otherwise too large normally. Of course this option may slow down VS Code, so the option defaults to `false`.