### PR TITLE
Allow any character in filename in  parsed cppcheck output

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -42,7 +42,7 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
     diagnosticCollection.clear();
 
     // 1 = path, 2 = line, 3 = severity, 4 = message
-    let regex = /^(?:\[([\w:\\/.-]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
+    let regex = /^(?:\[([\w\W]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
     let cppcheckOutput = runLintMode(config, vscode.workspace.rootPath);
     let regexArray: RegExpExecArray;
     let fileData: {[key:string]:RegExpExecArray[]} = {};


### PR DESCRIPTION
This fixes issue #7. 
The issue was caused by a too restrictive regex for parsing the cppcheck output. My directory happened to have spaces, a plus, and a comma (don't ask...), all of which were not picked up by the regex.