### PR TITLE
Revert "Allow any character in filename in  parsed cppcheck output"

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -42,7 +42,7 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
     diagnosticCollection.clear();
 
     // 1 = path, 2 = line, 3 = severity, 4 = message
-    let regex = /^(?:\[([\w\W]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
+    let regex = /^(?:\[([\w:\\/.-]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
     let cppcheckOutput = runLintMode(config, vscode.workspace.rootPath);
     let regexArray: RegExpExecArray;
     let fileData: {[key:string]:RegExpExecArray[]} = {};


### PR DESCRIPTION
Reverts matthewferreira/cppcheck-extension#10.

Sorry but the regex is wrong. It matches nearly the entirety of the output of cppcheck, causing the linter to crash vscode when looking at the filename, as getCorrectFileName returns null.