### PR TITLE
Fixed overly greedy matching for filename

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -42,7 +42,7 @@ export function Lint(diagnosticCollection: vscode.DiagnosticCollection, config: 
     diagnosticCollection.clear();
 
     // 1 = path, 2 = line, 3 = severity, 4 = message
-    let regex = /^(?:\[([\w:\\/.-]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
+    let regex = /^(?:\[([\w\W][^\]]+):(\d+)]: )?\((\w+)\) ([\s\S]+?)\n/gm;
     let cppcheckOutput = runLintMode(config, vscode.workspace.rootPath);
     let regexArray: RegExpExecArray;
     let fileData: {[key:string]:RegExpExecArray[]} = {};


### PR DESCRIPTION
Fixes #7. I now excluded the right hand square bracket. 
Note: this regexp allows any character in the filename, but as it is output from cppcheck we can assume the filename is a valid one, so we only have to detect what part is between [], not whether it is valid.